### PR TITLE
Fixed |AttributeError: 'Response' object has no attribute 'links'| error.

### DIFF
--- a/pyresto/core.py
+++ b/pyresto/core.py
@@ -460,7 +460,7 @@ class Model(object):
 
         """
 
-        return request.links.get('next', None)
+        return response.links.get('next', None)
 
     #: The class method which receives the class object and the body text of
     #: the server response to be parsed. It is expected to return a

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,1 @@
-requests==0.13.5
+requests==0.13.9


### PR DESCRIPTION
``` py
import pyresto.apis.github as GitHub

user = GitHub.User.get('berkerpeksag')
print 'Watchers: {0:d}'.format(sum(r.watchers for r in user.repos))
```

``` py
Traceback (most recent call last):
  File "hede.py", line 6, in <module>
    user = GitHub.User.get('berkerpeksag')
  File "/home/berker/hacking/pyresto/pyresto/core.py", line 674, in get
    data = cls._rest_call(url=path, auth=auth).data
  File "/home/berker/hacking/pyresto/pyresto/core.py", line 605, in _rest_call
    continuation_url = cls._continuator(response)
  File "/home/berker/hacking/pyresto/pyresto/core.py", line 463, in _continuator
    return response.links.get('next', None)
AttributeError: 'Response' object has no attribute 'links'
```
