### PR TITLE
Implement multiple service support to Bugzilla API

### DIFF
--- a/pyresto/apis/bugzilla/__init__.py
+++ b/pyresto/apis/bugzilla/__init__.py
@@ -1,8 +1,50 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from .models import *
+import imp
+import os.path
 
-__version__ = '0.1'
+__version__ = '0.2'
 __author__ = ('Berker Peksag <berker.peksag@gmail.com>',
               'Burak Yigit Kaya <ben@byk.im>')
+
+__models_file__ = os.path.join(os.path.dirname(__file__), 'models.py')
+__models_code__ = compile(open(__models_file__).read(),
+                          __models_file__, 'exec')
+
+__services__ = dict(
+    mozilla='https://api-dev.bugzilla.mozilla.org/latest/',
+    mozilla_test='https://api-dev.bugzilla.mozilla.org/test/latest/',
+    mozilla11='https://api-dev.bugzilla.mozilla.org/1.1/',
+    mozilla11_test='https://api-dev.bugzilla.mozilla.org/test/1.1/'
+)
+
+__all__ = ('Service',) + tuple(__services__.iterkeys())
+
+
+class Service(object):
+    def __init__(self, name, url):
+        self.name = name
+        self.module_name = '{0}.{1}'.format(__name__, self.name)
+        self.url = url
+        self.__namespace = None
+
+    @property
+    def namespace(self):
+        if self.__namespace is None:
+            # All these "namespacing tricks" are from (from slides 43+)
+            # https://speakerdeck.com/u/antocuni/p/python-white-magic?slide=87
+            self.__namespace = imp.new_module(self.module_name)
+            self.__namespace.__service_url__ = self.url
+            exec __models_code__ in self.__namespace.__dict__
+
+        return self.__namespace
+
+    def __getattr__(self, item):
+        return getattr(self.namespace, item)
+
+
+# Create services
+_globals = globals()
+for name, url in __services__.iteritems():
+    _globals[name] = Service(name, url)

--- a/pyresto/apis/bugzilla/models.py
+++ b/pyresto/apis/bugzilla/models.py
@@ -20,7 +20,7 @@ class QSAuth(AuthBase):
 
 
 class BugzillaModel(Model):
-    _url_base = 'https://api-dev.bugzilla.mozilla.org/latest/'
+    _url_base = __service_url__
 
     def __repr__(self):
         if hasattr(self, 'ref'):

--- a/pyresto/core.py
+++ b/pyresto/core.py
@@ -24,7 +24,11 @@ from abc import ABCMeta, abstractproperty, abstractmethod
 from urllib import quote
 
 
-__all__ = ('Error', 'Model', 'Many', 'Foreign')
+__all__ = ('PyrestoException',
+           'PyrestoServerResponseException',
+           'PyrestoInvalidRestMethodException',
+           'PyrestoInvalidAuthTypeException',
+           'Model', 'Many', 'Foreign')
 
 ALLOWED_HTTP_METHODS = frozenset(('GET', 'POST', 'PUT', 'DELETE', 'PATCH'))
 


### PR DESCRIPTION
This diff introduces a "Service" class that namespaces each bugzilla
service and sets the proper **service_url** global on the API module.

Usage is as follows:

```
from pyresto.apis import bugzilla

bugzilla.mozilla.Bug.get('774141')
```

Any bugzilla service that is not predefined can be defined as follows:

```
my_service = bugzilla.Service('my_service', 'https://api.bugzilla.myserver.com')
my_service.Bug.get('3141592')
```
